### PR TITLE
Add OAuth pass-through for Confluence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,51 @@
 # Johnny Five
 
-A friendly bot.  Initially started as a twitter bot, but it has grown to become 
-a general/multipurpose (email, Slack? Confluence?) notification helper library 
-to post things to places.
+A friendly bot.  
 
-![johnnyfive](https://github.com/LowellObservatory/JohnnyFive/blob/master/images/johnnyfive.jpg)
+This helper library currently contains classes for interacting with Confluence pages (creating, editing, attaching, etc.), interacting with Gmail (send and receive), posting to Slack (write only).
+
+![johnnyfive](https://github.com/LowellObservatory/JohnnyFive/blob/master/johnnyfive/images/johnnyfive.jpg)
+
+## JohnnyFive API
+
+```
+from johnnyfive import confluence as j5c
+j5c.ConfluencePage(space, page_title, instance=None, use_oauth=False)
+
+from johnnyfive import gmail as j5g
+j5g.GmailMessage(toaddr, subject, message_text, fromname=None fromaddr=None, interactive=False)
+j5g.GetMessages(label=None, after=None, before=None, interactive=False)
+
+from johnnyfive import slack as j5s
+j5s.SlackChannel(channel_name)
+```
+
 
 ## Requirements
 
-- requests
-- python-twitter
 - atlassian-python-api
+- beautifulsoup4
 - google-api-python-client
+- google-auth-httplib2
+- google-auth-oauthlib
+- lxml
+- pyjwt
+- python-twitter
+- slack_sdk
+- ligmos @ https://github.com/LowellObservatory/ligmos
 
 ## Installation
 
-In the source directory:
+Installable either as a standalone library:
 
-```pip install -e .```
+- In the source directory:
 
-and look for any compilation/installation failures for the dependencies.
+    ```pip install -e .```
+
+    and look for any compilation/installation failures for the dependencies.
+
+Or as a dependancy for other software:
+
+- In your package's `setup.cfg` file, add:
+
+    ```install_requires = JohnnyFive @ git+https://github.com/LowellObservatory/JohnnyFive```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ j5s.SlackChannel(channel_name)
 - lxml
 - pyjwt
 - python-twitter
+- requests
 - slack_sdk
 - ligmos @ https://github.com/LowellObservatory/ligmos
 

--- a/johnnyfive/__init__.py
+++ b/johnnyfive/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#  Created on 07-Mar-2022
+#
+#  @author: tbowers
+
+"""Init File
+"""
+
+
+# Imports for signal and log handling
+import os
+import warnings
+
+def short_warning(message, category, filename, lineno, file=None, line=None):
+    """
+    Return the format for a short warning message.
+    """
+    return f" {category.__name__}: {message} ({os.path.split(filename)[1]}:{lineno})\n"
+
+
+warnings.formatwarning = short_warning

--- a/johnnyfive/config/README.md
+++ b/johnnyfive/config/README.md
@@ -1,0 +1,23 @@
+## Configuration Files
+
+### Contents
+
+This directory contains the configuration files needed to authenticate a user or users for the various services.
+
+There are three files that must be present for normal operation, but at least two must be present at startup.
+
+* ```johnnyfive.conf``` -- Main configuration file where Confluence and Slack credentials are stored, along with the Gmail username.  Use the ```TEMPLATE``` file as a starting point to ensure all expected fields are populated.
+
+* ```gmail_credentials.json``` -- Gmail OAuth credentials.  Go to https://console.developers.google.com (signed in as the bot user) to create this credential.
+
+* ```gmail_token.json``` (optional) -- This file will be automatically created the first time you attempt to use one of the Gmail classes, but if you have one from a different installation of JohnnyFive, you may copy it in.
+
+### Install existing credential files
+
+If you have existing credential files from a different installation of JohnnyFive, the library comes with a command-line script for installing these in the proper location.
+
+After you have installed JohnnyFive, run:
+```
+$ j5_install_conf <filename>
+```
+where `<filename>` is the extant credential file.

--- a/johnnyfive/config/johnnyfive.conf-TEMPLATE
+++ b/johnnyfive/config/johnnyfive.conf-TEMPLATE
@@ -8,10 +8,7 @@ tokenSecret = here
 host = confluence
 user = None
 password = None
-access_token = None
-access_token_secret = None
-consumer_key = None
-key_cert = None
+access_token = Bot User OAuth Token
 
 [gmailSetup]
 user = email address

--- a/johnnyfive/confluence.py
+++ b/johnnyfive/confluence.py
@@ -24,8 +24,6 @@ import requests
 # Internal Imports
 from . import utils
 
-warnings.formatwarning = utils.custom_formatwarning
-
 
 # Set API Components
 __all__ = ['ConfluencePage']

--- a/johnnyfive/confluence.py
+++ b/johnnyfive/confluence.py
@@ -19,6 +19,7 @@ import warnings
 
 # 3rd Party Libraries
 from atlassian import Confluence
+import requests
 
 # Internal Imports
 from . import utils
@@ -45,10 +46,10 @@ class ConfluencePage:
         An existing Confluence influence, to be used in the case of many
         instances of this class used in short order [Default: None]
     """
-    def __init__(self, space, page_title, instance=None):
+    def __init__(self, space, page_title, instance=None, use_oauth=False):
         self.space = space
         self.title = page_title
-        self.instance = setup_confluence() if not \
+        self.instance = setup_confluence(use_oauth=use_oauth) if not \
                             isinstance(instance, Confluence) else instance
         self.uname = self.instance.username
         self.space_perms = self._set_permdict()
@@ -327,11 +328,9 @@ def setup_confluence(use_oauth=False):
 
     # If we are using OAUTH, instantiate a Confluence object with it
     if use_oauth:
-        oauth_dict = {'access_token': setup.access_token,
-                      'access_token_secret': setup.access_token_secret,
-                      'consumer_key': setup.consumer_key,
-                      'key_cert': setup.key_cert}
-        return Confluence(url=setup.host, oauth=oauth_dict)
+        s = requests.Session()
+        s.headers['Authorization'] = f"Bearer {setup.access_token}"
+        return Confluence(url=setup.host, session=s)
 
     # Else, return a Confluence object instantiated with username/password
     return Confluence( url=setup.host,

--- a/johnnyfive/gmail.py
+++ b/johnnyfive/gmail.py
@@ -35,8 +35,6 @@ from google.oauth2.credentials import Credentials
 # Internal Imports
 from . import utils
 
-warnings.formatwarning = utils.custom_formatwarning
-
 
 # This scope is for sending email using the OAuth2 library
 SCOPES = ['https://www.googleapis.com/auth/gmail.modify']

--- a/johnnyfive/slack.py
+++ b/johnnyfive/slack.py
@@ -136,8 +136,6 @@ class SlackChannel:
                 for channel in result["channels"]:
                     if channel["name"] == name:
                         conversation_id = channel["id"]
-                        # Print result
-                        print(f"Found conversation ID: {conversation_id}")
                         break
 
         except SlackApiError as error:

--- a/johnnyfive/slack.py
+++ b/johnnyfive/slack.py
@@ -27,8 +27,6 @@ from slack_sdk.errors import SlackApiError
 # Internal Imports
 from . import utils
 
-warnings.formatwarning = utils.custom_formatwarning
-
 
 # Set API Components
 __all__ = ["SlackChannel"]

--- a/johnnyfive/utils.py
+++ b/johnnyfive/utils.py
@@ -58,6 +58,22 @@ class Paths:
     gmail_creds = os.path.join(config, "gmail_credentials.json")
 
 
+class authTarget(lig_utils.classes.baseTarget):
+    """authTarget Extension of LIGMOS baseTarget
+
+    Adds specified attributes used in JohnnyFive to silence LIGMOS's
+    "Setting orphan object key" messages
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.access_token = None
+        self.apiKey = None
+        self.apiSecret = None
+        self.tokenKey = None
+        self.tokenSecret = None
+
+
 def authenticate_gmail():
     """authenticate_gmail Console Script for authenticating Gmail
 
@@ -130,7 +146,7 @@ def read_ligmos_conffiles(confname, conffile="johnnyfive.conf"):
     """
     ligconf = lig_utils.confparsers.rawParser(os.path.join(Paths.config, conffile))
     ligconf = lig_workers.confUtils.assignConf(
-        ligconf[confname], lig_utils.classes.baseTarget, backfill=True
+        ligconf[confname], authTarget, backfill=True
     )
     return ligconf
 

--- a/johnnyfive/utils.py
+++ b/johnnyfive/utils.py
@@ -69,24 +69,6 @@ def authenticate_gmail():
     print("Whee!  We're going to authenticate gamil!")
 
 
-def custom_formatwarning(msg, category, *args, **kwargs):
-    """custom_formatwarning Custom Warning Formatting
-
-    Ignore everything except the message
-
-    Parameters
-    ----------
-    msg : `str`
-        The warning message
-
-    Returns
-    -------
-    `str`
-        The formatted warning string
-    """
-    return f"{category.__name__}: {str(msg)}\n"
-
-
 def install_conffiles(args=None):
     """install_conffiles Console Script for installing configuration files
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.2',  # Required
+    version='0.3',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,7 @@ setup(
                       'lxml',
                       'pyjwt',
                       'python-twitter',
+                      'requests',
                       'slack_sdk',
                       'ligmos @ git+https://github.com/LowellObservatory/ligmos'],
 

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ setup(
                       'google-auth-httplib2',
                       'google-auth-oauthlib',
                       'lxml',
+                      'pyjwt',
                       'python-twitter',
                       'slack_sdk',
                       'ligmos @ git+https://github.com/LowellObservatory/ligmos'],


### PR DESCRIPTION
* Connect the Confluence OAuth pass-through argument, allowing an external application to specify whether to use OAuth or uname/passwd for authentication.
* Updates to `README.md`